### PR TITLE
Skip workflow push when no commit was created

### DIFF
--- a/.github/workflows/fhem_test.yml
+++ b/.github/workflows/fhem_test.yml
@@ -41,13 +41,22 @@ jobs:
         LOG+=" - $(git log -1 --pretty=%B)"
         echo "$LOG" | cat - CHANGED  2>/dev/null >> temp || true  && mv temp CHANGED
     - name: git commit back
+      id: commit_back
       run: |
         git config --global user.email "action@github.com"
         git config --local user.name "GitHub Action"
+        before_commit=$(git rev-parse HEAD)
         git ls-files --error-unmatch ${CONTROLS_FILENAME} || git add ${CONTROLS_FILENAME}
         git ls-files --error-unmatch CHANGED || git add CHANGED
         git diff --name-only --exit-code controls_signalduino.txt || git commit CHANGED ${CONTROLS_FILENAME} -m "Automatic updated controls and CHANGED" || true
+        after_commit=$(git rev-parse HEAD)
+        if [ "$before_commit" != "$after_commit" ]; then
+          echo "committed=true" >> $GITHUB_OUTPUT
+        else
+          echo "committed=false" >> $GITHUB_OUTPUT
+        fi
     - name: git push
+      if: steps.commit_back.outputs.committed == 'true'
       uses: ad-m/github-push-action@v1.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+2026-05-12 - Skip workflow push when no commit was created
 2026-05-11 - Bump shogo82148/actions-setup-perl from 1.40.1 to 1.41.0 (#40)
 
 


### PR DESCRIPTION
## What changed

The `Fhem UnitTest` workflow now records whether the `git commit back` step actually created a commit. The following `git push` step only runs when that output is `true`.

## Why

Runs without repository write permissions were failing even when there was nothing to push, because the push action was executed unconditionally. Skipping the push when no commit was created avoids that unnecessary permission-sensitive step.

## Validation

- Parsed `.github/workflows/fhem_test.yml` with PyYAML
- Ran `git diff --check -- .github/workflows/fhem_test.yml`